### PR TITLE
FilePicker: Added the hability to put the directory manually

### DIFF
--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/CustomFilePickerActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/CustomFilePickerActivity.java
@@ -22,7 +22,6 @@ import com.nononsenseapps.filepicker.FilePickerFragment;
 
 import java.io.File;
 
-import org.dolphinemu.dolphinemu.NativeLibrary;
 import org.dolphinemu.dolphinemu.R;
 
 public final class CustomFilePickerActivity extends FilePickerActivity
@@ -39,8 +38,7 @@ public final class CustomFilePickerActivity extends FilePickerActivity
           final boolean singleClick)
   {
     mFilePickerFragment = new CustomFilePickerFragment();
-    // startPath is allowed to be null. In that case, default folder should be SD-card and not
-    // "/"
+    // startPath is allowed to be null. In that case, default folder should be SD-card and not "/"
     mFilePickerFragment.setArgs(startPath != null ?
                     startPath : Environment.getExternalStorageDirectory().getPath(),
             mode, allowMultiple, allowExistingFile, singleClick);
@@ -93,7 +91,7 @@ public final class CustomFilePickerActivity extends FilePickerActivity
     File path = new File(text);
     if (path.isDirectory())
     {
-      mFilePickerFragment.goToDir(path);
+      mFilePickerFragment.goToDir(path); // go to writted dir
     }
     else
     {

--- a/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/CustomFilePickerActivity.java
+++ b/Source/Android/app/src/main/java/org/dolphinemu/dolphinemu/activities/CustomFilePickerActivity.java
@@ -1,10 +1,20 @@
 package org.dolphinemu.dolphinemu.activities;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.net.Uri;
 import android.os.Environment;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.content.FileProvider;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.FileProvider;
 
 import com.nononsenseapps.filepicker.AbstractFilePickerFragment;
 import com.nononsenseapps.filepicker.FilePickerActivity;
@@ -12,32 +22,99 @@ import com.nononsenseapps.filepicker.FilePickerFragment;
 
 import java.io.File;
 
-public class CustomFilePickerActivity extends FilePickerActivity
+import org.dolphinemu.dolphinemu.NativeLibrary;
+import org.dolphinemu.dolphinemu.R;
 
+public final class CustomFilePickerActivity extends FilePickerActivity
+        implements DialogInterface.OnClickListener
 {
+
+  private CustomFilePickerFragment mFilePickerFragment;
+
+  @Override
+  protected AbstractFilePickerFragment<File> getFragment(@Nullable final String startPath,
+          final int mode,
+          final boolean allowMultiple,
+          final boolean allowExistingFile,
+          final boolean singleClick)
+  {
+    mFilePickerFragment = new CustomFilePickerFragment();
+    // startPath is allowed to be null. In that case, default folder should be SD-card and not
+    // "/"
+    mFilePickerFragment.setArgs(startPath != null ?
+                    startPath : Environment.getExternalStorageDirectory().getPath(),
+            mode, allowMultiple, allowExistingFile, singleClick);
+    return mFilePickerFragment;
+  }
+
   public static class CustomFilePickerFragment extends FilePickerFragment
   {
     @NonNull
     @Override
     public Uri toUri(@NonNull final File file)
     {
-      return FileProvider
-        .getUriForFile(getContext(),
-          getContext().getApplicationContext().getPackageName() + ".filesprovider",
-          file);
+      return FileProvider.getUriForFile(
+              getContext(),
+              getContext().getApplicationContext().getPackageName() + ".filesprovider", file);
+    }
+
+    public String getCurrentPath()
+    {
+      return mCurrentPath.toString();
     }
   }
 
   @Override
-  protected AbstractFilePickerFragment<File> getFragment(
-    @Nullable final String startPath, final int mode, final boolean allowMultiple,
-    final boolean allowExistingFile, final boolean singleClick)
+  public boolean onCreateOptionsMenu(Menu menu)
   {
-    AbstractFilePickerFragment<File> fragment = new CustomFilePickerFragment();
-    // startPath is allowed to be null. In that case, default folder should be SD-card and not "/"
-    fragment.setArgs(
-      startPath != null ? startPath : Environment.getExternalStorageDirectory().getPath(),
-      mode, allowMultiple, allowExistingFile, singleClick);
-    return fragment;
+    MenuInflater inflater = getMenuInflater();
+    inflater.inflate(R.menu.menu_file_picker, menu);
+    return true;
+  }
+
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item)
+  {
+    switch (item.getItemId())
+    {
+      case R.id.menu_current_directory:
+        showEditorDialog();
+        return true;
+    }
+
+    return false;
+  }
+
+  @Override
+  public void onClick(DialogInterface dialog, int which)
+  {
+    EditText editor = ((AlertDialog) dialog).findViewById(R.id.setting_editor);
+    String text = editor.getText().toString();
+    File path = new File(text);
+    if (path.isDirectory())
+    {
+      mFilePickerFragment.goToDir(path);
+    }
+    else
+    {
+      Toast.makeText(this, R.string.nnf_need_valid_filename, Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  private void showEditorDialog()
+  {
+    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+    LayoutInflater inflater = LayoutInflater.from(this);
+    View view = inflater.inflate(R.layout.dialog_editor, null);
+
+    builder.setTitle(R.string.add_directory_up_one_level);
+    builder.setView(view);
+    builder.setPositiveButton(android.R.string.ok, this);
+    builder.show();
+
+    EditText editor = view.findViewById(R.id.setting_editor);
+    editor.setText(mFilePickerFragment.getCurrentPath());
+    editor.requestFocus();
   }
 }

--- a/Source/Android/app/src/main/res/drawable/outline_drive_file_rename_outline_24.xml
+++ b/Source/Android/app/src/main/res/drawable/outline_drive_file_rename_outline_24.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15,16l-4,4l10,0l0,-4z"/>
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12.06,7.19L3,16.25V20h3.75l9.06,-9.06L12.06,7.19zM5.92,18H5v-0.92l7.06,-7.06l0.92,0.92L5.92,18z"/>
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18.71,8.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34C16.17,4.09 15.92,4 15.66,4c-0.25,0 -0.51,0.1 -0.7,0.29l-1.83,1.83l3.75,3.75L18.71,8.04z"/>
+</vector>

--- a/Source/Android/app/src/main/res/layout/dialog_editor.xml
+++ b/Source/Android/app/src/main/res/layout/dialog_editor.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_margin="0dp"
+    android:padding="0dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <EditText
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        android:id="@+id/setting_editor"
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        android:textSize="16sp"
+        android:gravity="top|start"
+        android:scrollbars="horizontal|vertical"
+        android:typeface="monospace"
+        android:inputType="textMultiLine"
+        android:autofillHints=""
+        tools:ignore="LabelFor" />
+
+</RelativeLayout>

--- a/Source/Android/app/src/main/res/menu/menu_file_picker.xml
+++ b/Source/Android/app/src/main/res/menu/menu_file_picker.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_current_directory"
+        android:title="@string/add_directory_up_one_level"
+        android:icon="@drawable/outline_drive_file_rename_outline_24"
+        app:showAsAction="always"/>
+
+</menu>


### PR DESCRIPTION
This is a port of a new citra MMJ feature (https://github.com/weihuoya/citra/commit/c1eba2bd787f8bf51766cf3cdacfd82493983086) to allow put the directory manually, a very cool "fix" for scoped storage and SDCards!!

Here a view of the feature:
https://user-images.githubusercontent.com/76565986/156196664-4e193393-7975-45aa-a8f8-cc08224123fd.mp4

